### PR TITLE
fix(deps): install ca-certificates too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,12 @@ LABEL org.opencontainers.image.base.name="docker.io/_/ubuntu:latest"
 # See also https://systemd.io/CONTAINER_INTERFACE
 ENV container docker
 
-# Install systemd
+# Install systemd and ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends \
     systemd \
     init \
     python3 \
+    ca-certificates \
     && \
     apt-get clean
 


### PR DESCRIPTION
this should fix the unknown root CA while doing molecule tests

```
failed: [instance] (item={'key': 'microsoft-packages', 'value': {'url': 'https://packages.microsoft.com/keys/microsoft.asc', 'filename': 'microsoft-packages'}}) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "microsoft-packages", "value": {"filename": "microsoft-packages", "url": "https://packages.microsoft.com/keys/microsoft.asc"}}, "msg": "Failed to download key at https://packages.microsoft.com/keys/microsoft.asc: Request failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:997)>"}
```